### PR TITLE
"Untagged" is now an implicit category

### DIFF
--- a/index.js
+++ b/index.js
@@ -504,7 +504,7 @@ app.get('/items', async (req, res) => {
                         <a class="waves-effect waves-light btn filter-types-none"><i class="material-icons left">not_interested</i>None</a>
                     </div>
                     <div class="type-filters">${typeFilters}</div>
-                    <div>Special Handlers</div>
+                    <div>Special Filters</div>
                     <div>
                         <a class="waves-effect waves-light btn filter-special-all"><i class="material-icons left">all_inclusive</i>All</a>
                         <a class="waves-effect waves-light btn filter-special-none"><i class="material-icons left">not_interested</i>None</a>

--- a/public/common.js
+++ b/public/common.js
@@ -22,10 +22,9 @@ const AVAILABLE_TYPES = [
 ];
 
 const CUSTOM_HANDLERS = [
-    'untagged',
-    'missing-image',
-    'no-wiki',
     'all',
+    'missing-image',
+    'no-wiki'
 ];
 
 const formatPrice = (price) => {

--- a/public/items.js
+++ b/public/items.js
@@ -257,12 +257,14 @@ jQuery.fn.dataTableExt.afnFiltering.push(
             } else if (filter === 'no-wiki') {
                 if (!item.wiki_link) specialPassed = true;
             }
+            if (specialPassed) break;
         }
         let typeChecked = jQuery('input.filter-type:checked');
         if (typeof typeChecked == 'undefined') return false;
         for (let i=0; i< typeChecked.length; i++) {
             if (item.types.includes(jQuery(typeChecked[i]).val())) {
                 typePassed = true;
+                break;
             }
         }
         return specialPassed && typePassed;

--- a/public/items.js
+++ b/public/items.js
@@ -244,14 +244,14 @@ jQuery.fn.dataTableExt.afnFiltering.push(
         const item = all_items[iDataIndex];
         let specialPassed = false;
         let typePassed = false;
+        let allItems = false;
         let specialChecked = jQuery('input.filter-special:checked');
         if (typeof specialChecked == 'undefined') return false;
         for (let i=0; i< specialChecked.length; i++) {
             const filter = jQuery(specialChecked[i]).val();
             if (filter === 'all') {
                 specialPassed = true;
-            } else if (filter === 'untagged') {
-                if (item.types.length == 0) return true;
+                allItems = true;
             } else if (filter === 'missing-image') {
                 if (!aData[1] || !aData[2] || !aData[3]) specialPassed = true;
             } else if (filter === 'no-wiki') {
@@ -267,6 +267,7 @@ jQuery.fn.dataTableExt.afnFiltering.push(
                 break;
             }
         }
+        if (item.types.length == 0 && allItems) typePassed = true;
         return specialPassed && typePassed;
     }
 );


### PR DESCRIPTION
The untagged items are now shown by selecting "all" under the special filters and deselecting all the types. Literally, show me all the items that don't have any types assigned. That seems most intuitive and least complex.